### PR TITLE
Feature/log stream sink split

### DIFF
--- a/auth0/resource_auth0_log_stream.go
+++ b/auth0/resource_auth0_log_stream.go
@@ -85,7 +85,6 @@ func newLogStream() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Sensitive:   true,
-							ForceNew:    true,
 							Description: "Name of the Partner Topic to be used with Azure, if the type is 'eventgrid'",
 						},
 						"http_content_format": {
@@ -142,7 +141,6 @@ func newLogStream() *schema.Resource {
 						"splunk_secure": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
 						},
 					},
 				},

--- a/auth0/resource_auth0_log_stream_test.go
+++ b/auth0/resource_auth0_log_stream_test.go
@@ -53,10 +53,10 @@ func TestAccLogStreamHTTP(t *testing.T) {
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-http-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "http"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "status", "paused"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_endpoint", "https://example.com/webhook/logs"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_type", "application/json"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_format", "JSONLINES"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_endpoint", "https://example.com/webhook/logs"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_content_type", "application/json"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_content_format", "JSONLINES"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
 				),
 			},
 			{
@@ -64,10 +64,10 @@ func TestAccLogStreamHTTP(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-http-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "http"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_endpoint", "https://example.com/webhook/logs"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_type", "application/json; charset=utf-8"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_format", "JSONARRAY"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_endpoint", "https://example.com/webhook/logs"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_content_type", "application/json; charset=utf-8"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_content_format", "JSONARRAY"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
 				),
 			},
 			{
@@ -75,10 +75,10 @@ func TestAccLogStreamHTTP(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-http-new-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "http"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_endpoint", "https://example.com/logs"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_type", "application/json"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_format", "JSONLINES"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_endpoint", "https://example.com/logs"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_content_type", "application/json"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_content_format", "JSONLINES"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "http_sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
 				),
 			},
 		},
@@ -90,7 +90,7 @@ resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-http-{{.random}}"
 	type = "http"
 	status = "paused"
-	sink {
+	http_sink {
 	  http_endpoint = "https://example.com/webhook/logs"
 	  http_content_type = "application/json"
 	  http_content_format = "JSONLINES"
@@ -102,7 +102,7 @@ const testAccLogStreamHTTPConfigUpdate = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-http-new-{{.random}}"
 	type = "http"
-	sink {
+	http_sink {
 	  http_endpoint = "https://example.com/logs"
 	  http_content_type = "application/json"
 	  http_content_format = "JSONLINES"
@@ -114,7 +114,7 @@ const testAccLogStreamHTTPConfigUpdateFormat = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-http-{{.random}}"
 	type = "http"
-	sink {
+	http_sink {
 	  http_endpoint = "https://example.com/webhook/logs"
 	  http_content_type = "application/json; charset=utf-8"
 	  http_content_format = "JSONARRAY"
@@ -135,8 +135,8 @@ func TestAccLogStreamEventBridge(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-aws-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "eventbridge"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.aws_account_id", "999999999999"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.aws_region", "us-west-2"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventbridge_sink.0.aws_account_id", "999999999999"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventbridge_sink.0.aws_region", "us-west-2"),
 				),
 			},
 			{
@@ -144,8 +144,8 @@ func TestAccLogStreamEventBridge(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-aws-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "eventbridge"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.aws_account_id", "899999999998"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.aws_region", "us-west-1"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventbridge_sink.0.aws_account_id", "899999999998"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventbridge_sink.0.aws_region", "us-west-1"),
 				),
 			},
 			{
@@ -153,8 +153,8 @@ func TestAccLogStreamEventBridge(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-aws-new-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "eventbridge"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.aws_account_id", "899999999998"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.aws_region", "us-west-1"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventbridge_sink.0.aws_account_id", "899999999998"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventbridge_sink.0.aws_region", "us-west-1"),
 				),
 			},
 		},
@@ -165,7 +165,7 @@ const logStreamAwsEventBridgeConfig = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-aws-{{.random}}"
 	type = "eventbridge"
-	sink {
+	eventbridge_sink {
 	  aws_account_id = "999999999999"
 	  aws_region = "us-west-2"
 	}
@@ -175,7 +175,7 @@ const logStreamAwsEventBridgeConfigUpdate = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-aws-{{.random}}"
 	type = "eventbridge"
-	sink {
+	eventbridge_sink {
 	  aws_account_id = "899999999998"
 	  aws_region = "us-west-1"
 	}
@@ -186,7 +186,7 @@ const logStreamAwsEventBridgeConfigUpdateName = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-aws-new-{{.random}}"
 	type = "eventbridge"
-	sink {
+	eventbridge_sink {
 	  aws_account_id = "899999999998"
 	  aws_region = "us-west-1"
 	}
@@ -209,9 +209,9 @@ func TestAccLogStreamEventGrid(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-azure-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "eventgrid"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.azure_subscription_id", "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.azure_region", "northeurope"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.azure_resource_group", "azure-logs-rg"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventgrid_sink.0.azure_subscription_id", "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventgrid_sink.0.azure_region", "northeurope"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventgrid_sink.0.azure_resource_group", "azure-logs-rg"),
 				),
 			},
 			{
@@ -219,9 +219,9 @@ func TestAccLogStreamEventGrid(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-azure-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "eventgrid"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.azure_subscription_id", "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.azure_region", "northeurope"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.azure_resource_group", "azure-logs-rg"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventgrid_sink.0.azure_subscription_id", "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventgrid_sink.0.azure_region", "northeurope"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "eventgrid_sink.0.azure_resource_group", "azure-logs-rg"),
 				),
 			},
 		},
@@ -232,7 +232,7 @@ const logStreamAzureEventGridConfig = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-azure-{{.random}}"
 	type = "eventgrid"
-	sink {
+	eventgrid_sink {
   	  azure_subscription_id = "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5"
 	  azure_region = "northeurope"
 	  azure_resource_group = "azure-logs-rg"
@@ -243,7 +243,7 @@ const logStreamAzureEventGridConfigUpdate = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-azure-{{.random}}"
 	type = "eventgrid"
-	sink {
+	eventgrid_sink {
   	  azure_subscription_id = "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5"
 	  azure_region = "westeurope"
 	  azure_resource_group = "azure-logs-rg"
@@ -264,8 +264,8 @@ func TestAccLogStreamDatadog(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-datadog-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "datadog"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.datadog_region", "us"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.datadog_api_key", "121233123455"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "datadog_sink.0.datadog_region", "us"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "datadog_sink.0.datadog_api_key", "121233123455"),
 				),
 			},
 			{
@@ -273,8 +273,8 @@ func TestAccLogStreamDatadog(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-datadog-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "datadog"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.datadog_region", "eu"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.datadog_api_key", "121233123455"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "datadog_sink.0.datadog_region", "eu"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "datadog_sink.0.datadog_api_key", "121233123455"),
 				),
 			},
 			{
@@ -282,8 +282,8 @@ func TestAccLogStreamDatadog(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-datadog-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "datadog"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.datadog_region", "eu"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.datadog_api_key", "1212331234556667"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "datadog_sink.0.datadog_region", "eu"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "datadog_sink.0.datadog_api_key", "1212331234556667"),
 				),
 			},
 		},
@@ -294,7 +294,7 @@ const logStreamDatadogConfig = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-datadog-{{.random}}"
 	type = "datadog"
-	sink {
+	datadog_sink {
 	  datadog_region = "us"
 	  datadog_api_key = "121233123455"
 	}
@@ -304,7 +304,7 @@ const logStreamDatadogConfigUpdate = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-datadog-{{.random}}"
 	type = "datadog"
-	sink {
+	datadog_sink {
 	  datadog_region = "eu"
 	  datadog_api_key = "121233123455"
 	}
@@ -314,7 +314,7 @@ const logStreamDatadogConfigRemoveAndCreate = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-datadog-{{.random}}"
 	type = "datadog"
-	sink {
+	datadog_sink {
 	  datadog_region = "eu"
 	  datadog_api_key = "1212331234556667"
 	}
@@ -334,10 +334,10 @@ func TestAccLogStreamSplunk(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-splunk-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "splunk"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_domain", "demo.splunk.com"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_token", "12a34ab5-c6d7-8901-23ef-456b7c89d0c1"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", "8088"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_secure", "true"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "splunk_sink.0.splunk_domain", "demo.splunk.com"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "splunk_sink.0.splunk_token", "12a34ab5-c6d7-8901-23ef-456b7c89d0c1"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "splunk_sink.0.splunk_port", "8088"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "splunk_sink.0.splunk_secure", "true"),
 				),
 			},
 			{
@@ -345,10 +345,10 @@ func TestAccLogStreamSplunk(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-splunk-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "splunk"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_domain", "prod.splunk.com"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_token", "12a34ab5-c6d7-8901-23ef-456b7c89d0d1"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", "8088"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_secure", "true"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "splunk_sink.0.splunk_domain", "prod.splunk.com"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "splunk_sink.0.splunk_token", "12a34ab5-c6d7-8901-23ef-456b7c89d0d1"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "splunk_sink.0.splunk_port", "8088"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "splunk_sink.0.splunk_secure", "true"),
 				),
 			},
 		},
@@ -359,7 +359,7 @@ const logStreamSplunkConfig = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-splunk-{{.random}}"
 	type = "splunk"
-	sink {
+	splunk_sink {
 	  splunk_domain = "demo.splunk.com"
 	  splunk_token = "12a34ab5-c6d7-8901-23ef-456b7c89d0c1"
 	  splunk_port = "8088"
@@ -371,7 +371,7 @@ const logStreamSplunkConfigUpdate = `
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-splunk-{{.random}}"
 	type = "splunk"
-	sink {
+	splunk_sink {
 	  splunk_domain = "prod.splunk.com"
 	  splunk_token = "12a34ab5-c6d7-8901-23ef-456b7c89d0d1"
 	  splunk_port = "8088"


### PR DESCRIPTION
@mcalster as discussed in [#270](https://github.com/alexkappa/terraform-provider-auth0/pull/270) I've restructured the schema so that instead of having a single `sink` object there are multiple, one for each log stream type.  By doing this we can validate much more effectively, as we don't have any confusing extraneous properties showing up in plans.

So with the validation, if you try something like this:
```
resource "auth0_log_stream" "log_stream" {
  name = var.auth0_log_stream_name
  type = "eventbridge"

  eventbridge_sink {
    aws_account_id = data.aws_caller_identity.current.account_id
    aws_region     = data.aws_region.current.name
  }

  eventgrid_sink {
    azure_subscription_id = "id"
    azure_region          = "region"
    azure_resource_group  = "rg"
  }
}
```
You can an error:
```
Error: "eventbridge_sink": only one of `datadog_sink,eventbridge_sink,eventgrid_sink,http_sink,splunk_sink` can be specified, but `eventbridge_sink,eventgrid_sink` were specified.

  on auth0_log_stream.tf line 1, in resource "auth0_log_stream" "log_stream":
   1: resource "auth0_log_stream" "log_stream" {
```
Likewise supplying neither block results in an error:
```
resource "auth0_log_stream" "log_stream" {
  name = var.auth0_log_stream_name
  type = "eventbridge"
}
```
```
Error: "eventbridge_sink": one of `datadog_sink,eventbridge_sink,eventgrid_sink,http_sink,splunk_sink` must be specified

  on auth0_log_stream.tf line 1, in resource "auth0_log_stream" "log_stream":
   1: resource "auth0_log_stream" "log_stream" {
```

Or supplying an EventGrid property in the EventBridge sink:
```
resource "auth0_log_stream" "log_stream" {
  name = var.auth0_log_stream_name
  type = "eventbridge"

  eventbridge_sink {
    aws_account_id        = data.aws_caller_identity.current.account_id
    aws_region            = data.aws_region.current.name
    azure_subscription_id = "id"
  }
}
```
```
Error: Unsupported argument

  on auth0_log_stream.tf line 9, in resource "auth0_log_stream" "log_stream":
   9:     azure_subscription_id = "id"

An argument named "azure_subscription_id" is not expected here.
```

Applying shows the expected properties:
```
  # auth0_log_stream.log_stream will be created
  + resource "auth0_log_stream" "log_stream" {
      + id     = (known after apply)
      + name   = "Auth0Events1"
      + status = (known after apply)
      + type   = "eventbridge"

      + eventbridge_sink {
          + aws_account_id           = (sensitive value)
          + aws_partner_event_source = (sensitive value)
          + aws_region               = "eu-west-1"
        }
    }
```
As do update, recreate and destroy:
```
  # auth0_log_stream.log_stream will be updated in-place
  ~ resource "auth0_log_stream" "log_stream" {
        id     = "<REDACTED>"
      ~ name   = "Auth0Events1" -> "Auth0Events"
        status = "active"
        type   = "eventbridge"

        eventbridge_sink {
            aws_account_id           = (sensitive value)
            aws_partner_event_source = (sensitive value)
            aws_region               = "eu-west-1"
        }
    }
```
```
  # auth0_log_stream.log_stream must be replaced
-/+ resource "auth0_log_stream" "log_stream" {
      ~ id     = "<REDACTED>" -> (known after apply)
        name   = "Auth0Events"
      ~ status = "active" -> (known after apply)
        type   = "eventbridge"

      ~ eventbridge_sink {
            aws_account_id           = (sensitive value)
          ~ aws_partner_event_source = (sensitive value)
          ~ aws_region               = "eu-west-1" -> "us-east-1" # forces replacement
        }
    }
```
```
  # auth0_log_stream.log_stream must be replaced
-/+ resource "auth0_log_stream" "log_stream" {
      ~ id     = "<REDACTED>" -> (known after apply)
        name   = "Auth0Events"
      ~ status = "active" -> (known after apply)
        type   = "eventbridge"

      ~ eventbridge_sink {
            aws_account_id           = (sensitive value)
          ~ aws_partner_event_source = (sensitive value)
          ~ aws_region               = "eu-west-1" -> "us-east-1" # forces replacement
        }
    }
```

The unused sink properties are empty at the top level, so there's no opportunity for the `http_custom_headers` and `splunk_secure` properties to cause confusion:
```
{
  "mode": "managed",
  "type": "auth0_log_stream",
  "name": "log_stream",
  "provider": "provider.auth0",
  "instances": [
    {
      "schema_version": 0,
      "attributes": {
        "datadog_sink": [],
        "eventbridge_sink": [
          {
            "aws_account_id": "<REDACTED>",
            "aws_partner_event_source": "<REDACTED>",
            "aws_region": "eu-west-1"
          }
        ],
        "eventgrid_sink": [],
        "http_sink": [],
        "id": "<REDACTED>",
        "name": "Auth0Events1",
        "splunk_sink": [],
        "status": "active",
        "type": "eventbridge"
      },
      "private": "<REDACTED>"
    }
  ]
}
```

I've run the acceptance tests and all pass.  I've also tried this with AWS EventBridge in my own module and it seems to work fine.

The main thing I'm not happy with at the moment is the `type` property also being set, and there being nothing to stop the `type` and sink object not matching up.  I started looking at removing the `type` property and just relying on the type of the sink object which is set, but it started getting a bit too involved, so I thought I'd send this first to get yours and @alexkappa's thoughts.

What do you think?